### PR TITLE
Fixing several warnings and errors in the IM oils

### DIFF
--- a/data/oil/IM/IM00001.json
+++ b/data/oil/IM/IM00001.json
@@ -95,6 +95,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -115,187 +116,7 @@
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
-                            "value": 22.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
                             "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 27.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 45.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 55.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 60.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 65.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 70.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 75.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 85.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0742881120767641,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -314,60 +135,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.242506381041646,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 105.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.242506381041646,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.242506381041646,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 115.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.326615515524086,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 120.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.326615515524086,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 125.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -398,48 +171,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.494833784488968,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 140.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.494833784488968,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 145.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.536888351730188,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 150.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.536888351730188,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 155.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -458,42 +195,6 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.578942918971409,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 165.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.578942918971409,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 170.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.578942918971409,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 175.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.620997486212629,
                             "unit": "%",
                             "unit_type": "volumefraction"
@@ -506,48 +207,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.620997486212629,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 185.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.66305205345385,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 190.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.66305205345385,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 195.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.103478989381175,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 200.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2132,7 +1797,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 3.9,
                     "unit": "%",

--- a/data/oil/IM/IM00001.json
+++ b/data/oil/IM/IM00001.json
@@ -1797,11 +1797,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.08,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 3.9,
                     "unit": "%",

--- a/data/oil/IM/IM00001.json
+++ b/data/oil/IM/IM00001.json
@@ -96,6 +96,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -602,7 +607,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00002.json
+++ b/data/oil/IM/IM00002.json
@@ -1784,11 +1784,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.46,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 5.7,
                     "unit": "%",

--- a/data/oil/IM/IM00002.json
+++ b/data/oil/IM/IM00002.json
@@ -95,6 +95,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -589,7 +594,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00002.json
+++ b/data/oil/IM/IM00002.json
@@ -94,6 +94,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -103,246 +104,6 @@
                         },
                         "vapor_temp": {
                             "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 45.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 55.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 60.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 70.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 75.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 85.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 95.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 100.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 105.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 115.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 120.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 125.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -415,18 +176,6 @@
                         },
                         "vapor_temp": {
                             "value": 155.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.321771647961204,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 160.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -517,18 +266,6 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.922039286942562,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 200.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 2.69791961354991,
                             "unit": "%",
                             "unit_type": "volumefraction"
@@ -583,66 +320,6 @@
                         },
                         "vapor_temp": {
                             "value": 250.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 3.88689633462947,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 260.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 3.96806628045691,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 270.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 4.07565466262136,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 280.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 4.22599456365029,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 290.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 4.4781940999543,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 300.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2107,7 +1784,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 5.7,
                     "unit": "%",

--- a/data/oil/IM/IM00003.json
+++ b/data/oil/IM/IM00003.json
@@ -165,6 +165,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -695,7 +700,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00003.json
+++ b/data/oil/IM/IM00003.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -164,6 +164,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -185,42 +186,6 @@
                         },
                         "vapor_temp": {
                             "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.337080643124141,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 24.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.337080643124141,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 27.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.337080643124141,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 39.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -305,18 +270,6 @@
                         },
                         "vapor_temp": {
                             "value": 125.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.872899039994308,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 140.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -413,18 +366,6 @@
                         },
                         "vapor_temp": {
                             "value": 250.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 7.66526686620209,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 230.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1949,7 +1890,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 8.4,
                     "unit": "%",
@@ -2015,7 +1955,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2032,7 +1972,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2049,7 +1989,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2066,7 +2006,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00003.json
+++ b/data/oil/IM/IM00003.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1890,11 +1890,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.46,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 8.4,
                     "unit": "%",
@@ -1960,7 +1971,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1977,7 +1988,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1994,7 +2005,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2011,7 +2022,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00004.json
+++ b/data/oil/IM/IM00004.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1806,11 +1806,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.48,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 8.5,
                     "unit": "%",
@@ -1876,7 +1887,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1893,7 +1904,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1910,7 +1921,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1927,7 +1938,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00004.json
+++ b/data/oil/IM/IM00004.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -164,6 +164,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -173,126 +174,6 @@
                         },
                         "vapor_temp": {
                             "value": 20.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 22.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 33.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 42.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 75.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 100.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 125.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -401,30 +282,6 @@
                         },
                         "vapor_temp": {
                             "value": 250.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 4.93143443599062,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 210.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 5.87503816215978,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 220.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1949,7 +1806,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 8.5,
                     "unit": "%",
@@ -2015,7 +1871,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2032,7 +1888,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2049,7 +1905,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2066,7 +1922,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00004.json
+++ b/data/oil/IM/IM00004.json
@@ -165,6 +165,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -611,7 +616,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00005.json
+++ b/data/oil/IM/IM00005.json
@@ -103,7 +103,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -120,7 +120,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -137,7 +137,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -154,7 +154,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1967,11 +1967,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.47,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 10.8,
                     "unit": "%",
@@ -2037,7 +2048,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2054,7 +2065,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2071,7 +2082,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2088,7 +2099,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00005.json
+++ b/data/oil/IM/IM00005.json
@@ -103,7 +103,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -120,7 +120,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -137,7 +137,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -154,7 +154,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -169,6 +169,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -190,90 +191,6 @@
                         },
                         "vapor_temp": {
                             "value": 22.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.079366516190502,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.079366516190502,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.079366516190502,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.079366516190502,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.079366516190502,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.079366516190502,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 65.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.079366516190502,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 75.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -418,18 +335,6 @@
                         },
                         "vapor_temp": {
                             "value": 160.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.86438802648798,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 170.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2062,7 +1967,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 10.8,
                     "unit": "%",
@@ -2128,7 +2032,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2145,7 +2049,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2162,7 +2066,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2179,7 +2083,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00005.json
+++ b/data/oil/IM/IM00005.json
@@ -170,6 +170,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -772,7 +777,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00006.json
+++ b/data/oil/IM/IM00006.json
@@ -165,6 +165,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -683,7 +688,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00006.json
+++ b/data/oil/IM/IM00006.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -164,6 +164,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -173,138 +174,6 @@
                         },
                         "vapor_temp": {
                             "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.629826789489804,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 22.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.629826789489804,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.629826789489804,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 24.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.629826789489804,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.629826789489804,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.629826789489804,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.629826789489804,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.629826789489804,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 47.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.629826789489804,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.412471287784545,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 77.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.369000187443493,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -323,96 +192,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.587364020059648,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.674306220741752,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 105.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.848190622105959,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 100.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.891661722447011,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 120.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 1.28290162551648,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 160.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.54372822756279,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 141.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.97843923097331,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 150.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 2.28273693336067,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 155.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -491,7 +276,7 @@
                     },
                     {
                         "fraction": {
-                            "value": 8.06439327872057,
+                            "value": 10.93348590123,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
@@ -2093,7 +1878,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 26.2,
                     "unit": "%",
@@ -2159,7 +1943,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2176,7 +1960,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00006.json
+++ b/data/oil/IM/IM00006.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1878,11 +1878,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.45,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 26.2,
                     "unit": "%",
@@ -1948,7 +1959,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1965,7 +1976,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00007.json
+++ b/data/oil/IM/IM00007.json
@@ -165,6 +165,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -695,7 +700,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00007.json
+++ b/data/oil/IM/IM00007.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -164,6 +164,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -185,66 +186,6 @@
                         },
                         "vapor_temp": {
                             "value": 24.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.172256652876604,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 26.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.172256652876604,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.172256652876604,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.172256652876604,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.172256652876604,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -287,30 +228,6 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.513635023892676,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 105.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.513635023892676,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.598979616646694,
                             "unit": "%",
                             "unit_type": "volumefraction"
@@ -323,48 +240,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.598979616646694,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 125.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.684324209400712,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 130.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.684324209400712,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 135.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.684324209400712,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 145.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -401,18 +282,6 @@
                         },
                         "vapor_temp": {
                             "value": 185.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.19639176592482,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 190.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2021,7 +1890,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 6.2,
                     "unit": "%",
@@ -2087,7 +1955,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2104,7 +1972,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2121,7 +1989,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2138,7 +2006,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00007.json
+++ b/data/oil/IM/IM00007.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1890,11 +1890,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.49,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 6.2,
                     "unit": "%",
@@ -1960,7 +1971,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1977,7 +1988,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1994,7 +2005,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2011,7 +2022,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00008.json
+++ b/data/oil/IM/IM00008.json
@@ -165,6 +165,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -803,7 +808,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00008.json
+++ b/data/oil/IM/IM00008.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1998,11 +1998,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.49,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 14.6,
                     "unit": "%",
@@ -2068,7 +2079,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2085,7 +2096,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2102,7 +2113,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2119,7 +2130,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00008.json
+++ b/data/oil/IM/IM00008.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -164,6 +164,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -185,30 +186,6 @@
                         },
                         "vapor_temp": {
                             "value": 26.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.534209147434021,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.534209147434021,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -257,18 +234,6 @@
                         },
                         "vapor_temp": {
                             "value": 95.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.860423857018628,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 100.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2033,7 +1998,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 14.6,
                     "unit": "%",
@@ -2099,7 +2063,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2116,7 +2080,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2133,7 +2097,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2150,7 +2114,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00009.json
+++ b/data/oil/IM/IM00009.json
@@ -2013,11 +2013,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.08,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 21.1,
                     "unit": "%",
@@ -2083,7 +2094,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2100,7 +2111,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00009.json
+++ b/data/oil/IM/IM00009.json
@@ -96,6 +96,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -818,7 +823,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00009.json
+++ b/data/oil/IM/IM00009.json
@@ -95,6 +95,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -116,78 +117,6 @@
                         },
                         "vapor_temp": {
                             "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.05642695448317,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 27.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.05642695448317,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 29.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.05642695448317,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.05642695448317,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.05642695448317,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.05642695448317,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 45.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -380,18 +309,6 @@
                         },
                         "vapor_temp": {
                             "value": 130.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 4.67339510734941,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 135.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2096,7 +2013,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 21.1,
                     "unit": "%",
@@ -2162,7 +2078,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2179,7 +2095,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00010.json
+++ b/data/oil/IM/IM00010.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1770,11 +1770,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.47,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 2.6,
                     "unit": "%",
@@ -1840,7 +1851,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1857,7 +1868,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1874,7 +1885,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1891,7 +1902,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00010.json
+++ b/data/oil/IM/IM00010.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -164,6 +164,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -185,18 +186,6 @@
                         },
                         "vapor_temp": {
                             "value": 185.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.464037287663749,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 190.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -257,18 +246,6 @@
                         },
                         "vapor_temp": {
                             "value": 250.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.777012929212852,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 200.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1793,7 +1770,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 2.6,
                     "unit": "%",
@@ -1859,7 +1835,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1876,7 +1852,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1893,7 +1869,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1910,7 +1886,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00010.json
+++ b/data/oil/IM/IM00010.json
@@ -165,6 +165,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -575,7 +580,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00011.json
+++ b/data/oil/IM/IM00011.json
@@ -165,6 +165,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -611,7 +616,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 252.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 252.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00011.json
+++ b/data/oil/IM/IM00011.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -164,6 +164,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -173,90 +174,6 @@
                         },
                         "vapor_temp": {
                             "value": 20.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 29.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 31.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 36.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -311,18 +228,6 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.14767226572688,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 170.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.316963732562461,
                             "unit": "%",
                             "unit_type": "volumefraction"
@@ -365,42 +270,6 @@
                         },
                         "vapor_temp": {
                             "value": 240.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.94317214530284,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 200.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.26138457364187,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 210.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.63261835083685,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 220.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1937,7 +1806,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 2.4,
                     "unit": "%",
@@ -2003,7 +1871,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2020,7 +1888,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2037,7 +1905,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2054,7 +1922,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00011.json
+++ b/data/oil/IM/IM00011.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1806,11 +1806,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.49,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 2.4,
                     "unit": "%",
@@ -1876,7 +1887,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1893,7 +1904,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1910,7 +1921,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1927,7 +1938,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00012.json
+++ b/data/oil/IM/IM00012.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1914,11 +1914,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.48,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 19.0,
                     "unit": "%",
@@ -1984,7 +1995,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00012.json
+++ b/data/oil/IM/IM00012.json
@@ -165,6 +165,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -719,7 +724,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00012.json
+++ b/data/oil/IM/IM00012.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -164,6 +164,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -179,120 +180,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 24.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 100.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.0664560753830801,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 120.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0664560753830801,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 124.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -341,18 +234,6 @@
                         },
                         "vapor_temp": {
                             "value": 145.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.72593254597132,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -521,18 +402,6 @@
                         },
                         "vapor_temp": {
                             "value": 250.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 11.5531710240299,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 200.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -845,18 +714,6 @@
                         },
                         "vapor_temp": {
                             "value": 510.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 57.6910071826228,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 520.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2057,7 +1914,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 19.0,
                     "unit": "%",
@@ -2123,7 +1979,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00013.json
+++ b/data/oil/IM/IM00013.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -164,6 +164,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -191,72 +192,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.067426229539972,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 26.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.067426229539972,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.067426229539972,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.067426229539972,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 45.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.0765076392483409,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0765076392483409,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 65.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -485,30 +426,6 @@
                         },
                         "vapor_temp": {
                             "value": 250.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 9.29639801181456,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 200.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 11.6889637844162,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 210.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2033,7 +1950,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 14.8,
                     "unit": "%",
@@ -2075,7 +1991,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00013.json
+++ b/data/oil/IM/IM00013.json
@@ -98,7 +98,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -115,7 +115,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -132,7 +132,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -149,7 +149,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100,
+                            "value": 100.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1950,11 +1950,22 @@
                     },
                     "comment": "Pseudo-component of the SINTEF OSCAR Characterization"
                 }
+            ],
+            "bulk_composition": [
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.48,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    }
+                }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 14.8,
                     "unit": "%",
@@ -1996,7 +2007,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00013.json
+++ b/data/oil/IM/IM00013.json
@@ -165,6 +165,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -755,7 +760,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00020.json
+++ b/data/oil/IM/IM00020.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 14.96,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -126,102 +127,6 @@
                         },
                         "vapor_temp": {
                             "value": 22.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.307138528584445,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.307138528584445,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 24.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.307138528584445,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.307138528584445,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.307138528584445,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 29.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.307138528584445,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 42.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.307138528584445,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.307138528584445,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 94.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1949,7 +1854,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 2.80909090909092,
                     "unit": "%",
@@ -1998,7 +1902,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00020.json
+++ b/data/oil/IM/IM00020.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -648,7 +653,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00021.json
+++ b/data/oil/IM/IM00021.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -600,7 +605,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00021.json
+++ b/data/oil/IM/IM00021.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 25.02,
         "labels": [
+            "ULSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "ULSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -114,90 +115,6 @@
                         },
                         "vapor_temp": {
                             "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 24.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 26.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 31.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 33.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1889,7 +1806,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 3.6980385099874,
                     "unit": "%",
@@ -1938,7 +1854,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00022.json
+++ b/data/oil/IM/IM00022.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -600,7 +605,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00022.json
+++ b/data/oil/IM/IM00022.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 14.26,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -126,162 +127,6 @@
                         },
                         "vapor_temp": {
                             "value": 20.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 33.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 34.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 100.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.19289298133666,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 140.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -324,36 +169,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.633306242008776,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 158.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.809471546277622,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 170.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.809471546277622,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 155.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -390,30 +211,6 @@
                         },
                         "vapor_temp": {
                             "value": 200.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 2.83537254536936,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 184.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 2.92345519750378,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 194.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2009,7 +1806,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 5.01362397820164,
                     "unit": "%",
@@ -2058,7 +1854,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00023.json
+++ b/data/oil/IM/IM00023.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 25.35,
         "labels": [
+            "ULSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "ULSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -114,222 +115,6 @@
                         },
                         "vapor_temp": {
                             "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 31.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 33.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 140.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 150.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 160.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 170.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 180.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 190.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.790832652889485,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 200.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.149120441739305,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 210.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1913,7 +1698,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 4.46922309854045,
                     "unit": "%",
@@ -1962,7 +1746,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00023.json
+++ b/data/oil/IM/IM00023.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -492,7 +497,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00024.json
+++ b/data/oil/IM/IM00024.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -612,7 +617,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 270.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 270.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00024.json
+++ b/data/oil/IM/IM00024.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 18.96,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -126,126 +127,6 @@
                         },
                         "vapor_temp": {
                             "value": 24.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 28.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 38.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 49.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 45.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.119719316058603,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 48.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -426,30 +307,6 @@
                         },
                         "vapor_temp": {
                             "value": 270.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.65564677812455,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 210.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.25539320561711,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 260.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1961,7 +1818,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 1.68067226890754,
                     "unit": "%",
@@ -2010,7 +1866,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00025.json
+++ b/data/oil/IM/IM00025.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -564,7 +569,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00025.json
+++ b/data/oil/IM/IM00025.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 10.74,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -126,102 +127,6 @@
                         },
                         "vapor_temp": {
                             "value": 24.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0169566504720525,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 28.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0169566504720525,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 26.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0169566504720525,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 31.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0169566504720525,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0169566504720525,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0169566504720525,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 100.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0169566504720525,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0169566504720525,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1865,7 +1770,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 8.0297938050686,
                     "unit": "%",
@@ -1914,7 +1818,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00027.json
+++ b/data/oil/IM/IM00027.json
@@ -164,6 +164,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -694,7 +699,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 260.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 260.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00027.json
+++ b/data/oil/IM/IM00027.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 16.51,
         "labels": [
-            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product"
+            "Refined product",
+            "VLSFO"
         ],
         "gnome_suitable": true
     },
@@ -97,7 +97,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -114,7 +114,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -131,7 +131,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -148,7 +148,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1899,12 +1899,22 @@
                         "unit_type": "massfraction"
                     },
                     "comment": "Computed on the 250\u00b0C residue by taking into account the evaporation"
+                },
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.387,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    },
+                    "comment": "Value from the Certificate of Analysis provided by the supplier"
                 }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 3.20705005905333,
                     "unit": "%",
@@ -1970,7 +1980,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1987,7 +1997,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2004,7 +2014,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00027.json
+++ b/data/oil/IM/IM00027.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 16.51,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -97,7 +97,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -114,7 +114,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -131,7 +131,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -148,7 +148,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -163,243 +163,16 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
-                            "value": -0.0271215248453949,
+                            "value": 0.0,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 22.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 29.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 37.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 34.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 55.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 60.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 65.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 75.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 78.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 72.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0271215248453949,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 70.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.0184098413712421,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.00969815789708931,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": -0.000986474422936496,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 95.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -430,18 +203,6 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.0251485759995219,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 115.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.0425719429478276,
                             "unit": "%",
                             "unit_type": "volumefraction"
@@ -466,18 +227,6 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.0599953098961332,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.0948420437927444,
                             "unit": "%",
                             "unit_type": "volumefraction"
@@ -496,18 +245,6 @@
                         },
                         "vapor_temp": {
                             "value": 145.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.164535511585967,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 140.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -568,18 +305,6 @@
                         },
                         "vapor_temp": {
                             "value": 200.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.852758506044039,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 195.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2175,7 +1900,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 3.20705005905333,
                     "unit": "%",
@@ -2241,7 +1965,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2258,7 +1982,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2275,7 +1999,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00028.json
+++ b/data/oil/IM/IM00028.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 19.48,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -97,7 +97,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -114,7 +114,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -131,7 +131,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -148,7 +148,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -163,6 +163,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -178,180 +179,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 29.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 31.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 33.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 38.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.216600941643843,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 88.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.225105928496685,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 90.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.225105928496685,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 85.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.225105928496685,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 95.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -388,18 +221,6 @@
                         },
                         "vapor_temp": {
                             "value": 120.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.301650810172268,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -496,42 +317,6 @@
                         },
                         "vapor_temp": {
                             "value": 260.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.557438607200815,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 200.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.832553004935293,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 230.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.922514850429771,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 240.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2055,7 +1840,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 0.852298485810145,
                     "unit": "%",
@@ -2121,7 +1905,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2138,7 +1922,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2155,7 +1939,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00028.json
+++ b/data/oil/IM/IM00028.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 19.48,
         "labels": [
-            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product"
+            "Refined product",
+            "VLSFO"
         ],
         "gnome_suitable": true
     },
@@ -97,7 +97,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -114,7 +114,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -131,7 +131,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -148,7 +148,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1839,12 +1839,22 @@
                         "unit_type": "massfraction"
                     },
                     "comment": "Computed on the 250\u00b0C residue by taking into account the evaporation"
+                },
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.493,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    },
+                    "comment": "Value from the Certificate of Analysis provided by the supplier"
                 }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 0.852298485810145,
                     "unit": "%",
@@ -1910,7 +1920,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1927,7 +1937,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1944,7 +1954,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00028.json
+++ b/data/oil/IM/IM00028.json
@@ -164,6 +164,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -634,7 +639,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 260.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 260.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00029.json
+++ b/data/oil/IM/IM00029.json
@@ -164,6 +164,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -706,7 +711,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00029.json
+++ b/data/oil/IM/IM00029.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 26.56,
         "labels": [
+            "ULSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "ULSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -97,7 +97,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -114,7 +114,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -131,7 +131,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -148,7 +148,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -163,6 +163,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -172,114 +173,6 @@
                         },
                         "vapor_temp": {
                             "value": 20.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.205088899315625,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 22.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.205088899315625,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.205088899315625,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 27.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.205088899315625,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 28.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.205088899315625,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 29.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.205088899315625,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.205088899315625,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 31.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.205088899315625,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.205088899315625,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -298,96 +191,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.213200020522239,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.213200020522239,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 55.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.213200020522239,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 65.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.213200020522239,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 75.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.213200020522239,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 85.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.213200020522239,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 95.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.237533384142083,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 100.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.269977868968541,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 92.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -448,30 +257,6 @@
                         },
                         "vapor_temp": {
                             "value": 135.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.545755989993437,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 145.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.545755989993437,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 155.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2127,7 +1912,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 7.43230964928222,
                     "unit": "%",
@@ -2193,7 +1977,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2210,7 +1994,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2227,7 +2011,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00029.json
+++ b/data/oil/IM/IM00029.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 26.56,
         "labels": [
-            "ULSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product"
+            "Refined product",
+            "ULSFO"
         ],
         "gnome_suitable": true
     },
@@ -97,7 +97,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -114,7 +114,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -131,7 +131,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -148,7 +148,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1911,12 +1911,22 @@
                         "unit_type": "massfraction"
                     },
                     "comment": "Computed on the 250\u00b0C residue by taking into account the evaporation"
+                },
+                {
+                    "name": "Sulfur",
+                    "measurement": {
+                        "value": 0.099,
+                        "unit": "%",
+                        "unit_type": "massfraction"
+                    },
+                    "comment": "Value from the Certificate of Analysis provided by the supplier"
                 }
             ]
         },
         {
             "metadata": {
                 "name": "250\u00b0C residues",
+                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 7.43230964928222,
                     "unit": "%",
@@ -1982,7 +1992,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -1999,7 +2009,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -2016,7 +2026,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10,
+                            "value": 10.0,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00030.json
+++ b/data/oil/IM/IM00030.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -684,7 +689,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 227.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 227.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00030.json
+++ b/data/oil/IM/IM00030.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 13.7,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -132,54 +133,6 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.380257707659629,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 29.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.380257707659629,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 28.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.380257707659629,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 34.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.380257707659629,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 33.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.468014603278883,
                             "unit": "%",
                             "unit_type": "volumefraction"
@@ -192,60 +145,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.468014603278883,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.555771498898137,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 100.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.555771498898137,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 105.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.555771498898137,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 95.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.555771498898137,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 85.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -270,18 +175,6 @@
                         },
                         "vapor_temp": {
                             "value": 125.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.731285290136644,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1997,7 +1890,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 14.4402379664683,
                     "unit": "%",
@@ -2046,7 +1938,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00031.json
+++ b/data/oil/IM/IM00031.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 15.4,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": false
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00032.json
+++ b/data/oil/IM/IM00032.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 27.91,
         "labels": [
+            "ULSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "ULSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -114,150 +115,6 @@
                         },
                         "vapor_temp": {
                             "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 26.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 27.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 100.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 120.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2009,7 +1866,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 6.05785798494606,
                     "unit": "%",

--- a/data/oil/IM/IM00032.json
+++ b/data/oil/IM/IM00032.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -660,7 +665,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00033.json
+++ b/data/oil/IM/IM00033.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 12.75,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -126,42 +127,6 @@
                         },
                         "vapor_temp": {
                             "value": 19.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0199442102979524,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0199442102979524,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 28.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0199442102979524,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1901,7 +1866,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 4.4789679294994,
                     "unit": "%",
@@ -1950,7 +1914,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00033.json
+++ b/data/oil/IM/IM00033.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -660,7 +665,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00034.json
+++ b/data/oil/IM/IM00034.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -540,7 +545,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00034.json
+++ b/data/oil/IM/IM00034.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 26.64,
         "labels": [
+            "ULSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "ULSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -114,234 +115,6 @@
                         },
                         "vapor_temp": {
                             "value": 22.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 27.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 55.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 75.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 105.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 120.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 140.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 150.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 160.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 170.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 175.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 180.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 185.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1973,7 +1746,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 6.11485288904644,
                     "unit": "%",
@@ -2022,7 +1794,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00036.json
+++ b/data/oil/IM/IM00036.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 17.95,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -120,168 +121,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 24.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 28.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 29.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 31.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 38.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 45.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 48.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 60.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.0143791974844328,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 85.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0229663967581505,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -372,36 +217,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.53819835318121,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 145.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.581134349549798,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 150.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.581134349549798,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 155.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -558,18 +379,6 @@
                         },
                         "vapor_temp": {
                             "value": 250.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 7.82102417206382,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 210.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2105,7 +1914,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 11.0485701316387,
                     "unit": "%",
@@ -2154,7 +1962,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00036.json
+++ b/data/oil/IM/IM00036.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -708,7 +713,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00037.json
+++ b/data/oil/IM/IM00037.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -600,7 +605,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00037.json
+++ b/data/oil/IM/IM00037.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 16.23,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -114,186 +115,6 @@
                         },
                         "vapor_temp": {
                             "value": 20.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 23.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 28.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 29.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 31.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 34.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 33.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 43.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 48.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 53.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 63.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 74.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 80.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 72.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 100.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -336,30 +157,6 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.251177345811336,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.294413610044121,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 135.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.337649874276906,
                             "unit": "%",
                             "unit_type": "volumefraction"
@@ -378,18 +175,6 @@
                         },
                         "vapor_temp": {
                             "value": 170.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.380886138509691,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 180.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2021,7 +1806,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 2.51219953009219,
                     "unit": "%",
@@ -2070,7 +1854,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00038.json
+++ b/data/oil/IM/IM00038.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -600,7 +605,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 250.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {

--- a/data/oil/IM/IM00038.json
+++ b/data/oil/IM/IM00038.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 15.93,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -132,84 +133,12 @@
                     },
                     {
                         "fraction": {
-                            "value": 1.880204965664,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.880204965664,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 35.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.880204965664,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 32.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.880204965664,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 31.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.880204965664,
+                            "value": 1.88867748488287,
                             "unit": "%",
                             "unit_type": "volumefraction"
                         },
                         "vapor_temp": {
                             "value": 34.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.88867748488287,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 85.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.88867748488287,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 90.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -246,30 +175,6 @@
                         },
                         "vapor_temp": {
                             "value": 120.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 2.09201794613586,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 130.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 2.09201794613586,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 140.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -366,30 +271,6 @@
                         },
                         "vapor_temp": {
                             "value": 250.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 4.53038165620435,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 210.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 5.8155013703477,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 230.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -1925,7 +1806,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 4.32093310948132,
                     "unit": "%",
@@ -1974,7 +1854,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00039.json
+++ b/data/oil/IM/IM00039.json
@@ -13,10 +13,10 @@
         "product_type": "Residual Fuel Oil",
         "API": 17.97,
         "labels": [
+            "VLSFO",
             "Fuel oil",
             "LSFO",
-            "Refined product",
-            "VLSFO"
+            "Refined product"
         ],
         "gnome_suitable": true
     },
@@ -73,7 +73,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -90,7 +90,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 100.0,
+                            "value": 100,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }
@@ -105,6 +105,7 @@
                 }
             },
             "distillation_data": {
+                "type": "volume fraction",
                 "cuts": [
                     {
                         "fraction": {
@@ -114,174 +115,6 @@
                         },
                         "vapor_temp": {
                             "value": 20.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 21.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 22.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 25.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 28.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 30.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 33.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 38.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 37.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 40.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 45.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 42.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 50.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 55.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.0,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 70.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -324,18 +157,6 @@
                     },
                     {
                         "fraction": {
-                            "value": 0.153421977738698,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 110.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
                             "value": 0.196396989097171,
                             "unit": "%",
                             "unit_type": "volumefraction"
@@ -354,18 +175,6 @@
                         },
                         "vapor_temp": {
                             "value": 135.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 0.239372000455645,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 150.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -450,30 +259,6 @@
                         },
                         "vapor_temp": {
                             "value": 250.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.21417120150455,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 220.0,
-                            "unit": "C",
-                            "unit_type": "temperature"
-                        }
-                    },
-                    {
-                        "fraction": {
-                            "value": 1.5352209851907,
-                            "unit": "%",
-                            "unit_type": "volumefraction"
-                        },
-                        "vapor_temp": {
-                            "value": 230.0,
                             "unit": "C",
                             "unit_type": "temperature"
                         }
@@ -2009,7 +1794,6 @@
         {
             "metadata": {
                 "name": "250\u00b0C residues",
-                "short_name": "250\u00b0C residu...",
                 "fraction_evaporated": {
                     "value": 2.23534756928668,
                     "unit": "%",
@@ -2058,7 +1842,7 @@
                             "unit_type": "temperature"
                         },
                         "shear_rate": {
-                            "value": 10.0,
+                            "value": 10,
                             "unit": "1/s",
                             "unit_type": "angularvelocity"
                         }

--- a/data/oil/IM/IM00039.json
+++ b/data/oil/IM/IM00039.json
@@ -106,6 +106,11 @@
             },
             "distillation_data": {
                 "type": "volume fraction",
+                "fraction_recovered": {
+                    "value": 100.0,
+                    "unit": "%",
+                    "unit_type": "volumefraction"
+                },
                 "cuts": [
                     {
                         "fraction": {
@@ -588,7 +593,7 @@
                         }
                     }
                 ],
-                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 255.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added."
+                "comment": "The values under 200.0 \u00b0C are coming from laboratory data, the value above 255.0 \u00b0C are coming from the true boiling point data. Each value between the two (included) are average of the laboratory and the TBP, when only one is present, the point is not added. Points with a fraction equal or smaller than the previous one is not added either. Recovered fraction is put at 100%."
             },
             "compounds": [
                 {


### PR DESCRIPTION
Fixing some warning and errors for the oils:

- Adding API
- Removing distillation entries that were negative and not strictly increasing.

There does not seems to be any errors left, but still some warnings:

-  Distillation fraction recovered is missing or invalid as they were directly provided
- Some oil have no viscosity because the measurement in the lab determined they were solid
- IM 31 has no distillation curve (no possible to do in the lab)